### PR TITLE
Fix Next Step button on the Mac Yubikey page

### DIFF
--- a/_pages/mac-yubikey.md
+++ b/_pages/mac-yubikey.md
@@ -10,4 +10,4 @@ header:
 
 {% include yubikey.md %}
 
-[Next Step &rarr;](/mac-yubikey/){: .btn .btn--success .btn--large}
+[Next Step &rarr;](/mac-druva/){: .btn .btn--success .btn--large}


### PR DESCRIPTION
Fixed Next Step button redirecting to its own page. It now goes to the next step correctly