### PR TITLE
fix: correct Okta Fastpass page link in mac-chrome.md

### DIFF
--- a/_pages/mac-chrome.md
+++ b/_pages/mac-chrome.md
@@ -22,18 +22,18 @@ Before we move forward, it's critical to set Google Chrome as your Default Brows
 
 ## Setting up Okta Fastpass to work with Google Chrome
 
-__Note:__ If you don’t see the Okta Verify app on your computer, please don't install it from the App store. Ensure that you have completed all updates from the [Managed Software Center &rarr;](/mac-installs.md). If the Managed Software Center is not on your computer, please follow this [link &rarr;](/mac-mdm.md) to manually install it. It is critical for Okta Verify to be installed by the Managed Software Center.  
+__Note:__ If you don't see the Okta Verify app on your computer, please don't install it from the App store. Ensure that you have completed all updates from the [Managed Software Center &rarr;](/mac-installs.md). If the Managed Software Center is not on your computer, please follow this [link &rarr;](/mac-mdm.md) to manually install it. It is critical for Okta Verify to be installed by the Managed Software Center.  
 
-{% include mac-okta-fastpass-page.md %}
+[Okta Fastpass Setup](/mac-okta-fastpass-page/)
 
 ## Signing into Google Chrome
 * Open Google Chrome
 * Click the profile icon in the top right corner
-* Click “Turn on sync…”
+* Click "Turn on sync..."
 
 {% include figure url="/assets/images/mac-chrome-13.png" image_path="/assets/images/mac-chrome-13.png" %}
 
-* Select “Use Okta Fastpass”
+* Select "Use Okta Fastpass"
 
 {% include figure url="/assets/images/mac-chrome-14.png" image_path="/assets/images/mac-chrome-14.png" %}
 
@@ -41,15 +41,15 @@ __Note:__ If you don’t see the Okta Verify app on your computer, please don't 
 
 {% include figure url="/assets/images/mac-chrome-15.png" image_path="/assets/images/mac-chrome-15.png" %}
 
-* Once verified, Google Chrome will reopen. Click “Continue” on the Identity Verification screen.
+* Once verified, Google Chrome will reopen. Click "Continue" on the Identity Verification screen.
 
 {% include figure url="/assets/images/mac-chrome-16.png" image_path="/assets/images/mac-chrome-16.png" %}
 
-* Click “Continue” on the “Your organization will manage this profile” screen.
+* Click "Continue" on the "Your organization will manage this profile" screen.
 
 {% include figure url="/assets/images/mac-chrome-17.png" image_path="/assets/images/mac-chrome-17.png" %}
 
-* Click “Yes, I’m In” on the “Turn on sync” screen.
+* Click "Yes, I'm In" on the "Turn on sync" screen.
 
 {% include figure url="/assets/images/mac-chrome-18.png" image_path="/assets/images/mac-chrome-18.png" %}
 

--- a/_pages/mac-okta-fastpass-page.md
+++ b/_pages/mac-okta-fastpass-page.md
@@ -21,13 +21,13 @@ To confirm this on your MacBook, click on the Control Center icon in the top rig
 Now make sure Bluetooth is turned __on__ on your mobile device. Use your control center or mobile Settings to toggle Bluetooth on.
 {% include figure url="/assets/images/bluetooth-mobile.png" image_path="/assets/images/bluetooth-mobile.png" %}
 
-Back on your MacBook, Click the Okta Verify app that appears in the top right corner of your screen.
+Back on your MacBook, Click the __Okta Verify__ app icon that appears in the top right area of your screen.
 
 {% include figure url="/assets/images/mac-okta-icon-menu-bar.png" image_path="/assets/images/mac-okta-icon-menu-bar.png" %}
+{% include figure url="/assets/images/mac-okta-menu-bar.png" image_path="/assets/images/mac-okta-menu-bar.png" %}
 
 Next, click on __Open Okta Verify__ to open it, and click [Get Started](){: .btn .btn--inverse .btn--small}
 
-{% include figure url="/assets/images/mac-okta-menu-bar.png" image_path="/assets/images/mac-okta-menu-bar.png" %}
 {% include figure url="/assets/images/mac-oktafastpass-getstarted.png" image_path="/assets/images/mac-oktafastpass-getstarted.png" %}
 
 Select __Add Account__ under Add account from another device.


### PR DESCRIPTION
This page https://newcomputer.square.com/mac-chrome/
had bad instructions regarding opening Okta Verify via Launchpad. Since Okta is already opening, you cannot launch it via Launchpad, a Window would not appear
Also fixed image order on this page- https://newcomputer.square.com/mac-okta-fastpass-page/