### PR TITLE
Update onboarding flow to use YubiKey instead of Okta Verify Mobile (ITX-170490)

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -40,8 +40,6 @@ nav-mac:
       # url: /mac-password/
       - title: "Slack"
         url: /mac-slack/
-      - title: "Yubikey"
-        url: /mac-yubikey/
       - title: "Druva"
         url: /mac-druva/
       - title: "VPN"
@@ -88,8 +86,6 @@ nav-win:
         url: /win-password/
       - title: "Slack"
         url: /win-slack/
-      - title: "Yubikey"
-        url: /win-yubikey/
       - title: "Druva"
         url: /win-druva/
       - title: "VPN"

--- a/_includes/duo-setup-new.md
+++ b/_includes/duo-setup-new.md
@@ -1,12 +1,14 @@
-Enter your __username__,  then enter your newly created __password__, and click [Sign in](){: .btn .btn--inverse .btn--small}
+Enter your __username__, then enter your newly created __password__, and click [Sign in](){: .btn .btn--inverse .btn--small}
 
 __NOTE:__ Do not select __Sign with FastPass__, this will not work and needs to be set up at a later stage.
 {: .notice--warning}
 
 {% include figure url="/assets/images/okta-login-mac1.png" image_path="/assets/images/okta-login-mac1.png" %}
 
-Since you have already set up Okta Verify on your mobile device, you can now use it to authenticate in the next step:
-{% include figure url="/assets/images/okta-login-mac2.png" image_path="/assets/images/okta-login-mac2.png" %}
+You will be prompted to set up a security key. Insert your __YubiKey__ into a USB port on your laptop and follow the on-screen instructions to complete enrollment.
 
-On your mobile device, choose the corresponding number to the one that appears on your laptop.
-{% include figure url="/assets/images/okta-login-mac3.png" image_path="/assets/images/okta-login-mac3.png" %}
+{% include figure url="/assets/images/security-key-setup.png" image_path="/assets/images/security-key-setup.png" %}
+
+When prompted, tap the metal contact on your YubiKey to confirm the enrollment.
+
+{% include figure url="/assets/images/security-key-allow.png" image_path="/assets/images/security-key-allow.png" %}

--- a/_includes/mac-okta-fastpass-content.md
+++ b/_includes/mac-okta-fastpass-content.md
@@ -2,33 +2,24 @@ Let's set up __Okta Fastpass__.
 
 Okta FastPass provides a quick, easy and secure way to sign in and helps protect you from phishing.
 
-Before setting up Okta Verify, ensure that Bluetooth is enabled on your mobile device. Use your control center or mobile Settings to toggle Bluetooth on.
-{% include figure url="/assets/images/bluetooth-mobile.png" image_path="/assets/images/bluetooth-mobile.png" %}
-
-Back on your MacBook, Click the Okta Verify app that appears in the top right corner of your screen.
+On your MacBook, click the Okta Verify app that appears in the top right corner of your screen.
 
 <img src="/assets/images/mac-okta-icon-menu-bar.png" style="width: 192px !important; max-width: 192px !important;" />
 
-Next, click on __Open Okta Verify__ to open it, and click [Add account from another device](){: .btn .btn--inverse .btn--small}
+Next, click on __Open Okta Verify__ to open it, and click [Sign In](){: .btn .btn--inverse .btn--small}
 
 {% include figure url="/assets/images/mac-okta-menu-bar.png" image_path="/assets/images/mac-okta-menu-bar.png" %}
 {% include figure url="/assets/images/mac-oktafastpass-getstarted-new.png" image_path="/assets/images/mac-oktafastpass-getstarted-new.png" %}
 
-Select [Allow](){: .btn .btn--inverse .btn--small} to allow a bluetooth connection on your laptop. 
+Enter __login.block.xyz__ as your organization's sign-in URL, then click [Next](){: .btn .btn--inverse .btn--small}.
 
-{% include figure url="/assets/images/allow-bluetooth.png" image_path="/assets/images/allow-bluetooth.png" %}
-{% include figure url="/assets/images/allow-bluetooth-popup.png" image_path="/assets/images/allow-bluetooth-popup.png" %}
+Enter your __username__ and __password__, then click [Sign In](){: .btn .btn--inverse .btn--small}.
 
-Now open the Okta Verify app on your mobile device, select your Block account (Eg. `jsmith@block.xyz` or `jsmith@squareup.com`), then scroll down to select __Add Account to Another Device__.
+{% include figure url="/assets/images/okta-login-mac1.png" image_path="/assets/images/okta-login-mac1.png" %}
 
-{% include figure url="/assets/images/mac-okta-fastpass-add-mobile1.png" image_path="/assets/images/mac-okta-fastpass-add-mobile1.png" %}
+When prompted for additional verification, insert your __YubiKey__ and tap the metal contact to authenticate.
 
-You will now see an 8 character code below a QR code. Enter this code into Okta Verify desktop's "Enter code" field.
-{% include figure url="/assets/images/mac-okta-fastpass-mobile2.5.png" image_path="/assets/images/mac-okta-fastpass-mobile2.5.png" %}
-{% include figure url="/assets/images/mac-okta-fastpass-add-mobile2.png" image_path="/assets/images/mac-okta-fastpass-add-mobile2.png" %}
-
-Next, you may be asked to enter a PIN shown on your MacBook into your mobile Okta Verify app:
-{% include figure url="/assets/images/mac-okta-fastpass-add-mobile3.png" image_path="/assets/images/mac-okta-fastpass-add-mobile3.png" %}
+{% include figure url="/assets/images/security-key-allow.png" image_path="/assets/images/security-key-allow.png" %}
 
 __NOTE__: Biometrics (Touch ID) are preferred when using Okta FastPass. If you do not enable/use biometrics on your Block-issued device you will be prompted for another factor (password) when using Okta FastPass. 
 

--- a/_includes/mac-okta-fastpass.md
+++ b/_includes/mac-okta-fastpass.md
@@ -2,17 +2,7 @@ Let's set up __Okta Fastpass__.
 
 Okta FastPass provides a quick, easy and secure way to sign in and helps protect you from phishing.
 
-Before setting up Okta Verify, ensure that Bluetooth is enabled on both your MacBook and on your mobile device. 
-
-To confirm this on your MacBook, click on the Control Center icon in the top right corner.
-
-{% include figure url="/assets/images/bluetooth-mac.png" image_path="/assets/images/bluetooth-mac.png" %}
-{% include figure url="/assets/images/bluetooth-mac2.png" image_path="/assets/images/bluetooth-mac2.png" %}
-
-Now make sure Bluetooth is turned __on__ on your mobile device. Use your control center or mobile Settings to toggle Bluetooth on.
-{% include figure url="/assets/images/bluetooth-mobile.png" image_path="/assets/images/bluetooth-mobile.png" %}
-
-Back on your MacBook, Click the __Launchpad__ app in the dock at the bottom of your screen.
+On your MacBook, click the __Launchpad__ app in the dock at the bottom of your screen.
 
 {% include figure url="/assets/images/launchpad.png" image_path="/assets/images/launchpad.png" %}
 
@@ -20,24 +10,21 @@ Next, click on __Okta Verify__ to open it, and click [Get Started](){: .btn .btn
 
 {% include figure url="/assets/images/okta-verify-app.png" image_path="/assets/images/okta-verify-app.png" %}
 
-Select __Add Account__ under Add account from another device.
+Select __Sign In__ to add your account using your Okta credentials.
 
 {% include figure url="/assets/images/okta-fp-signin-new.png" image_path="/assets/images/okta-fp-signin-new.png" %}
 
-Now open the Okta Verify app on your mobile device, select your Block account (Eg. jsmith@block.xyz), then scroll down to select __Add Account to Another Device__.
+Enter __login.block.xyz__ as your organization's sign-in URL, then click [Next](){: .btn .btn--inverse .btn--small}.
 
-{% include figure url="/assets/images/mac-okta-fastpass-add-mobile1.png" image_path="/assets/images/mac-okta-fastpass-add-mobile1.png" %}
+Enter your __username__ and __password__, then click [Sign In](){: .btn .btn--inverse .btn--small}.
 
-You will now see an 8 character code below a QR code. Enter this code into Okta Verify desktop’s “Enter code” field.
-{% include figure url="/assets/images/mac-okta-fastpass-mobile2.5.png" image_path="/assets/images/mac-okta-fastpass-mobile2.5.png" %}
-{% include figure url="/assets/images/mac-okta-fastpass-add-mobile2.png" image_path="/assets/images/mac-okta-fastpass-add-mobile2.png" %}
+{% include figure url="/assets/images/okta-login-mac1.png" image_path="/assets/images/okta-login-mac1.png" %}
 
-Next, you may be asked to enter a PIN shown on your MacBook into your mobile Okta Verify app:
-{% include figure url="/assets/images/mac-okta-fastpass-add-mobile3.png" image_path="/assets/images/mac-okta-fastpass-add-mobile3.png" %}
+When prompted for additional verification, insert your __YubiKey__ and tap the metal contact to authenticate.
 
+{% include figure url="/assets/images/security-key-allow.png" image_path="/assets/images/security-key-allow.png" %}
 
 Note: Biometrics (Touch ID) are preferred when using Okta FastPass. If you do not enable/use biometrics on your Block-issued device you will be prompted for another factor (password) when using Okta FastPass. 
-
 
 {% include figure url="/assets/images/okta-fp-touchid-1.png" image_path="/assets/images/okta-fp-touchid-1.png" %}
 

--- a/_pages/contingent.md
+++ b/_pages/contingent.md
@@ -14,8 +14,11 @@ Welcome to Block! Let's get you setup so you can get to work right away. First, 
 * You can optionally join IT Office Hours to get technical support from a member of our IT Team if you run into any questions. The Google Meet link for this onboarding session will be provided to you via onboarding communications.
 
 ## 📱 Before you start!
-Before starting you will want to download the ![Okta Verify](/assets/images/duo-icon.png) __Okta Verify__ app from your phone's App Store. We will use this app for our 2-Factor Authentication. 
+Before starting you will need to set your initial Block password using the link sent to your personal email. You will use this password during device setup.
 
+Your laptop should have come with a __YubiKey__ (a small USB security key). You will use this YubiKey to enroll phishing-resistant MFA during device setup — keep it handy!
+
+{% include figure url="/assets/images/yubikey-5c-nfc.png" image_path="/assets/images/yubikey-5c-nfc.png" caption="YubiKey 5C NFC — included with your laptop" %}
 
 ## 💻 Laptop in hand?
 Have you received your official Block laptop and have it with you?

--- a/_pages/fte-new.md
+++ b/_pages/fte-new.md
@@ -12,9 +12,10 @@ Welcome to Block! Let's get you set up so you can get to work right away. First,
 * You can optionally join IT Office Hours to get technical support from a member of our IT Team if you run into any questions. The Google Meet link for this onboarding session will be provided to you via onboarding communications.
 
 ## 📱 Before you start!
-Before starting you will need to set your initial Block password. You will also want to download the ![Okta Verify](/assets/images/duo-icon.png) __Okta Verify__ app from your phone's App Store.
-[Download from the Apple App Store](https://apps.apple.com/na/app/okta-verify/id490179405)
-[Download from the Google Play Store](https://play.google.com/store/apps/details?id=com.okta.android.auth)
-Once this is installed, go ahead and __open it__.  We will use this app for our 2-Factor Authentication.
+Before starting you will need to set your initial Block password using the link sent to your personal email. You will use this password during device setup.
+
+Your laptop should have come with a __YubiKey__ (a small USB security key). You will use this YubiKey to enroll phishing-resistant MFA during device setup — keep it handy!
+
+{% include figure url="/assets/images/yubikey-5c-nfc.png" image_path="/assets/images/yubikey-5c-nfc.png" caption="YubiKey 5C NFC — included with your laptop" %}
 
 [Next](/okta-verify-mobile){: .btn .btn--success .btn--large}

--- a/_pages/mac-okta-fastpass-page.md
+++ b/_pages/mac-okta-fastpass-page.md
@@ -11,17 +11,7 @@ Let's set up __Okta Fastpass__.
 
 Okta FastPass provides a quick, easy and secure way to sign in and helps protect you from phishing.
 
-Before setting up Okta Verify, ensure that Bluetooth is enabled on both your MacBook and on your mobile device. 
-
-To confirm this on your MacBook, click on the Control Center icon in the top right corner.
-
-{% include figure url="/assets/images/bluetooth-mac.png" image_path="/assets/images/bluetooth-mac.png" %}
-{% include figure url="/assets/images/bluetooth-mac2.png" image_path="/assets/images/bluetooth-mac2.png" %}
-
-Now make sure Bluetooth is turned __on__ on your mobile device. Use your control center or mobile Settings to toggle Bluetooth on.
-{% include figure url="/assets/images/bluetooth-mobile.png" image_path="/assets/images/bluetooth-mobile.png" %}
-
-Back on your MacBook, Click the __Okta Verify__ app icon that appears in the top right area of your screen.
+On your MacBook, click the __Okta Verify__ app icon that appears in the top right area of your screen.
 
 {% include figure url="/assets/images/mac-okta-icon-menu-bar.png" image_path="/assets/images/mac-okta-icon-menu-bar.png" %}
 {% include figure url="/assets/images/mac-okta-menu-bar.png" image_path="/assets/images/mac-okta-menu-bar.png" %}
@@ -30,21 +20,19 @@ Next, click on __Open Okta Verify__ to open it, and click [Get Started](){: .btn
 
 {% include figure url="/assets/images/mac-oktafastpass-getstarted.png" image_path="/assets/images/mac-oktafastpass-getstarted.png" %}
 
-Select __Add Account__ under Add account from another device.
+Select __Sign In__ to add your account using your Okta credentials.
 
 {% include figure url="/assets/images/okta-fp-signin-new.png" image_path="/assets/images/okta-fp-signin-new.png" %}
 
-Now open the Okta Verify app on your mobile device, select your Block account (Eg. `jsmith@block.xyz` or `jsmith@squareup.com`), then scroll down to select __Add Account to Another Device__.
+Enter __login.block.xyz__ as your organization's sign-in URL, then click [Next](){: .btn .btn--inverse .btn--small}.
 
-{% include figure url="/assets/images/mac-okta-fastpass-add-mobile1.png" image_path="/assets/images/mac-okta-fastpass-add-mobile1.png" %}
+Enter your __username__ and __password__, then click [Sign In](){: .btn .btn--inverse .btn--small}.
 
-You will now see an 8 character code below a QR code. Enter this code into Okta Verify desktop’s “Enter code” field.
-{% include figure url="/assets/images/mac-okta-fastpass-mobile2.5.png" image_path="/assets/images/mac-okta-fastpass-mobile2.5.png" %}
-{% include figure url="/assets/images/mac-okta-fastpass-add-mobile2.png" image_path="/assets/images/mac-okta-fastpass-add-mobile2.png" %}
+{% include figure url="/assets/images/okta-login-mac1.png" image_path="/assets/images/okta-login-mac1.png" %}
 
-Next, you may be asked to enter a PIN shown on your MacBook into your mobile Okta Verify app:
-{% include figure url="/assets/images/mac-okta-fastpass-add-mobile3.png" image_path="/assets/images/mac-okta-fastpass-add-mobile3.png" %}
+When prompted for additional verification, insert your __YubiKey__ and tap the metal contact to authenticate.
 
+{% include figure url="/assets/images/security-key-allow.png" image_path="/assets/images/security-key-allow.png" %}
 
 __NOTE__: Biometrics (Touch ID) are preferred when using Okta FastPass. If you do not enable/use biometrics on your Block-issued device you will be prompted for another factor (password) when using Okta FastPass. 
 

--- a/_pages/mac-slack.md
+++ b/_pages/mac-slack.md
@@ -22,4 +22,4 @@ Click [OK](){: .btn .btn--inverse .btn--small} to give Slack access to your __Do
 
 {% include slackapp.md %}
 
-[Next Step &rarr;](/mac-yubikey){: .btn .btn--success .btn--large}
+[Next Step &rarr;](/mac-druva/){: .btn .btn--success .btn--large}

--- a/_pages/okta-verify-mobile.md
+++ b/_pages/okta-verify-mobile.md
@@ -1,44 +1,30 @@
 ---
 permalink: /okta-verify-mobile/
-title: "Okta Verify Mobile Setup"
+title: "Set Your Okta Password"
 header:
   overlay_color: "#333"
 ---
 
-<style>
-  .page__content figure img {
-    max-width: 85% !important;
-  }
-</style>
-# Setting up Okta Verify on Mobile:
+# Set Your Okta Password
 
-Your first login will be on your mobile device in the __Okta Verify__ app. Scroll through the following steps to add your account.
+Before setting up your new device, you need to set your initial Okta password using the link sent to your personal email.
 
-First, select the plus symbol near the top of the screen.
-{% include figure url="/assets/images/ovm-1.png" image_path="/assets/images/ovm-1.png"  %}
+## Steps:
 
-Choose the __Organization__ account type.
-{% include figure url="/assets/images/ovm-2.png" image_path="/assets/images/ovm-2.png"  %}
+1. Check your __personal email__ for the password setup link from Block IT.
+2. Open the link on your __personal device__ (phone or personal computer).
+3. Follow the prompts to create your Okta password.
 
-Skip the next step.
-{% include figure url="/assets/images/ovm-3.png" image_path="/assets/images/ovm-3.png"  %}
+__NOTE:__ Choose a strong password and remember it — you will need it during device setup.
+{: .notice--warning}
 
-Select __No, Sign In Instead__. A QR Code cannot be used.
-{% include figure url="/assets/images/ovm-4.png" image_path="/assets/images/ovm-4.png"  %}
+## What's next?
 
-Enter __login.block.xyz__ as your organization’s Sign-in URL.
-{% include figure url="/assets/images/ovm-5.png" image_path="/assets/images/ovm-5.png"  %}
+Once your password is set, you're ready to set up your new Block device. During device setup, you will enroll your __YubiKey__ (a small USB security key) as your phishing-resistant MFA method. Your YubiKey should have been included with your laptop — keep it handy!
 
-Enter your Block username: Eg. `jsmith`, then enter your Okta password.
-{% include figure url="/assets/images/okta-mobile-username.jpg" image_path="/assets/images/okta-mobile-username.jpg"  %}
-{% include figure url="/assets/images/okta-mobile-password.jpg" image_path="/assets/images/okta-mobile-password.jpg"  %}
+{% include figure url="/assets/images/yubikey-5c-nfc.png" image_path="/assets/images/yubikey-5c-nfc.png" caption="YubiKey 5C NFC — included with your laptop" %}
 
-If your device has biometrics, please __enable__ it in the next step.
-{% include figure url="/assets/images/ovm-8.png" image_path="/assets/images/ovm-8.png"  %}
+__NOTE:__ You no longer need to set up Okta Verify on your mobile device before starting device setup. YubiKey enrollment will happen during the MDM enrollment process on your new laptop.
+{: .notice--info}
 
-Done!
-{% include figure url="/assets/images/ovm-9.png" image_path="/assets/images/ovm-9.png"  %}
-
-Now you’re ready to set up your new computer!
-
-[👍  Let's begin!](/os){: .btn .btn--success .btn--large}
+[👍  Let's begin device setup!](/os){: .btn .btn--success .btn--large}

--- a/_pages/win-okta-fastpass.md
+++ b/_pages/win-okta-fastpass.md
@@ -12,34 +12,23 @@ header:
 
 __Okta FastPass__ provides a quick, easy, and secure way to sign in and helps protect you from phishing.
 
-First, make sure that you have Bluetooth enabled on __both your Windows machine and on your mobile device__. 
-To confirm this on your Windows machine, click on the Control Center icon in the bottom-right corner.
-Then confirm Bluetooth is also enabled on your mobile device. 
-
-{% include figure url="/assets/images/ofp-win1.png" image_path="/assets/images/ofp-win1.png" %}
-
 Open the __Okta Verify__ app on your Windows device by clicking the Start menu at the bottom of your screen, then searching for __Okta Verify__. 
 
 {% include figure url="/assets/images/ofp-win3.png" image_path="/assets/images/ofp-win3.png" %}
 
-Select __Add account from another device__.
+Select __Sign In__ to add your account using your Okta credentials.
 
 {% include figure url="/assets/images/ofp-win4.png" image_path="/assets/images/ofp-win4.png" caption="(Note that Okta Verify Desktop can be run in Light or Dark mode)" %}
 
-Now open Okta Verify on your mobile device, select your Block account (Eg. jsmith@block.xyz), then scroll down to select __Add Account to Another Device__.
+Enter __login.block.xyz__ as your organization's sign-in URL, then click [Next](){: .btn .btn--inverse .btn--small}.
 
-{% include figure url="/assets/images/ofp-win5.png" image_path="/assets/images/ofp-win5.png" %}
+Enter your __username__ and __password__, then click [Sign In](){: .btn .btn--inverse .btn--small}.
 
-You will now see an 8-character code below a QR code. 
+{% include figure url="/assets/images/okta-login-mac1.png" image_path="/assets/images/okta-login-mac1.png" %}
 
-{% include figure url="/assets/images/ofp-win6.png" image_path="/assets/images/ofp-win6.png" %}
+When prompted for additional verification, insert your __YubiKey__ and tap the metal contact to authenticate.
 
-Enter this code into Okta Verify desktop’s “Enter code” field.
-
-{% include figure url="/assets/images/ofp-win7.png" image_path="/assets/images/ofp-win7.png" %}
-
-You may be asked to enter a PIN shown on your laptop into your mobile Okta Verify app:
-{% include figure url="/assets/images/ofp-win8.png" image_path="/assets/images/ofp-win8.png" %}
+{% include figure url="/assets/images/security-key-allow.png" image_path="/assets/images/security-key-allow.png" %}
 
 __Note:__ Biometrics (Windows Hello) are preferred when using Okta FastPass. If you do not enable or use biometrics on your Block-issued device, you will be prompted for another factor (password) when using Okta FastPass.
 
@@ -48,10 +37,6 @@ __Note:__ Biometrics (Windows Hello) are preferred when using Okta FastPass. If 
 {% include figure url="/assets/images/ofp-win10.png" image_path="/assets/images/ofp-win10.png" %}
 
 If prompted, authenticate using Windows Hello.
-Success! 🎉 You’re all setup with Okta Fastpass!
+Success! 🎉 You're all setup with Okta Fastpass!
 
 [Next](/win-chrome){: .btn .btn--success} 
-
-
-
-

--- a/_pages/win-slack.md
+++ b/_pages/win-slack.md
@@ -36,4 +36,4 @@ Here at Block, we use Slack for instant messaging to enable quick communication 
 
 * Slack will open with the default channels. Feel free to take a look around or message your lead to let them know you’ve set it up. Then, move on to the next step, which is Druva.
 
-[Next Step &rarr;](/win-yubikey){: .btn .btn--success .btn--large}
+[Next Step &rarr;](/win-druva/){: .btn .btn--success .btn--large}


### PR DESCRIPTION
## ITX-170490: Update onboarding flow to use YubiKey instead of Okta Verify Mobile

### Summary
Updates newcomputer.square.com to reflect the new phishing-resistant MFA onboarding flow where new hires enroll their YubiKey during MDM enrollment instead of setting up Okta Verify on a mobile device beforehand.

### Changes

| File | Change |
|------|--------|
| `_pages/okta-verify-mobile.md` | Replaced 9-step Okta Verify mobile walkthrough with password setup instructions + YubiKey guidance |
| `_pages/fte-new.md` | Removed Okta Verify app download links; added YubiKey info |
| `_pages/contingent.md` | Same as above for contingent workers |
| `_includes/duo-setup-new.md` | Replaced Okta Verify mobile auth with YubiKey enrollment during MDM |
| `_pages/mac-slack.md` | Updated Next Step link to skip YubiKey page (Slack → Druva) |
| `_pages/win-slack.md` | Updated Next Step link to skip YubiKey page (Slack → Druva) |
| `_data/navigation.yml` | Removed YubiKey from Mac and Windows sidebar navigation |

### New Flow
1. New hire sets Okta password on personal device (`/okta-verify-mobile/` page)
2. New hire proceeds to device setup (`/os/` page)
3. YubiKey enrollment happens during MDM enrollment on the new laptop (`duo-setup-new.md` include)
4. No separate YubiKey setup step needed later in the Mac/Windows guides

### Notes for Reviewers
- The `/okta-verify-mobile/` permalink is preserved so existing links from onboarding emails won't break
- The images `security-key-setup.png` and `security-key-allow.png` already exist in assets — please verify they match the current YubiKey enrollment UI during MDM
- The standalone YubiKey pages (`mac-yubikey.md`, `win-yubikey.md`) still exist but are no longer linked from navigation or the setup flow — they can be removed in a follow-up if desired