### PR TITLE
Add Account Setup to the macOS sidebar nav

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -28,6 +28,8 @@ nav-mac:
     children:
       - title: "Setup"
         url: /mac/
+      - title: "Account Setup"
+        url: /mac-setup/
       - title: "Software Installation"
         url: /mac-installs/
       # - title: "Okta Fastpass"


### PR DESCRIPTION
The /mac-setup/ page (Okta sign-in, YubiKey enrollment, account creation) had no sidebar entry; the nav jumped from Setup straight to Software Installation.