### PR TITLE
Move default-browser setup to the Okta FastPass page

### DIFF
--- a/_pages/mac-chrome.md
+++ b/_pages/mac-chrome.md
@@ -9,14 +9,6 @@ header:
 ---
 # Google Chrome
 
-## Setting Up Google Chrome as your Default Browser
-Before we move forward, it's critical to set Google Chrome as your Default Browser.
-* Open System Settings. 
-* In the search bar, type "Default web browser" and select the option that appears.
-* Find the __Default web browser__ section and select Google Chrome to make it your default browser.
-
-{% include figure url="/assets/images/default-web-browser.png" image_path="/assets/images/default-web-browser.png" %}
-
 ## Signing into Google Chrome
 
 * Open the Google Chrome app on your computer, and click __Sign In__.

--- a/_pages/mac-okta-fastpass-page.md
+++ b/_pages/mac-okta-fastpass-page.md
@@ -11,6 +11,18 @@ header:
 
 Okta FastPass provides a quick, easy and secure way to sign in and helps protect you from phishing. Let's set it up before we configure Google Chrome.
 
+## Set Google Chrome as your default browser
+
+Signing in to Okta FastPass will open your web browser, so first make sure Google Chrome is set as your default browser.
+
+* Open System Settings.
+* In the search bar, type "Default web browser" and select the option that appears.
+* Find the __Default web browser__ section and select Google Chrome to make it your default browser.
+
+{% include figure url="/assets/images/default-web-browser.png" image_path="/assets/images/default-web-browser.png" %}
+
+## Set up Okta Verify
+
 __NOTE:__ Do not install Okta Verify from the App Store. It must be installed through the Managed Software Center. If you don't see Okta Verify on your computer, ensure you've completed all updates from the [Managed Software Center](/mac-installs/). If the Managed Software Center is not on your computer, please [contact IT](/help/) for further help.
 {: .notice--warning}
 


### PR DESCRIPTION
## Why

The Okta FastPass sign-in (YubiKey path) opens the web browser, but the "Set Google Chrome as your default browser" steps lived on the Chrome page — which comes **after** FastPass in the flow (#162). Users hit the browser-based sign-in before ever being told to set Chrome as their default.

## What changed

- **`/mac-okta-fastpass-page/`** now starts with a **"Set Google Chrome as your default browser"** section (System Settings → search "Default web browser" → select Google Chrome, with the existing screenshot), introduced by a line explaining why: signing in to FastPass opens the browser. The Okta Verify setup follows under its own heading.
- **`/mac-chrome/`** is now just "Signing into Google Chrome" — the default-browser section moved out.

## Testing

- Local `bundle exec jekyll build`: clean.
- Verified the default-browser section and figure render only on the FastPass page and no longer on the Chrome page, with headings in the right order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)